### PR TITLE
Add support for searching by regular expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,28 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,9 +47,9 @@ checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "autocfg"
@@ -42,10 +64,101 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "borsh"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
+dependencies = [
+ "borsh-derive",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0754613691538d51f329cce9af41d7b7ca150bc973056f1156611489475f54f7"
+dependencies = [
+ "borsh-derive-internal",
+ "borsh-schema-derive-internal",
+ "proc-macro-crate",
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "borsh-derive-internal"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "borsh-schema-derive-internal"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cast"
@@ -232,6 +345,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "getopts"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,6 +375,24 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.6",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash 0.8.3",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -415,12 +552,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "proc-macro-crate"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+dependencies = [
+ "toml",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -431,6 +597,12 @@ checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -504,14 +676,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
-name = "rust_decimal"
-version = "1.23.1"
+name = "rend"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22dc69eadbf0ee2110b8d20418c0c6edbaefec2811c4963dc17b6344e11fe0f8"
+checksum = "581008d2099240d37fb08d77ad713bcaec2c4d89d50b5b21a8bb1996bbab68ab"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0200c8230b013893c0b2d6213d6ec64ed2b9be2e0e016682b7224ff82cff5c58"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2e06b915b5c230a17d7a736d1e2e63ee753c256a8614ef3f5147b13a4f5541d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0446843641c69436765a35a5a77088e28c2e6a12da93e84aa3ab1cd4aa5a042"
 dependencies = [
  "arrayvec",
+ "borsh",
+ "bytecheck",
+ "byteorder",
+ "bytes",
  "num-traits",
+ "rand",
+ "rkyv",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -547,6 +763,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "secp256k1"
@@ -599,6 +821,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
 name = "syn"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +836,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tiny-keccak"
@@ -642,6 +876,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,6 +910,18 @@ name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
+name = "uuid"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
@@ -830,3 +1100,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +335,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +492,8 @@ version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -613,11 +630,12 @@ dependencies = [
 
 [[package]]
 name = "tinyvanityeth"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "criterion",
  "getopts",
  "num_cpus",
+ "regex",
  "rust_decimal",
  "secp256k1",
  "tiny-keccak",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,30 +3,22 @@
 version = 3
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "autocfg"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
-dependencies = [
- "autocfg 1.1.0",
-]
 
 [[package]]
 name = "autocfg"
@@ -36,21 +28,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata",
- "serde",
-]
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "bumpalo"
@@ -60,12 +40,9 @@ checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "cast"
-version = "0.2.7"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
-dependencies = [
- "rustc_version",
-]
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -80,45 +57,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "clap"
-version = "2.34.0"
+name = "ciborium"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
 dependencies = [
- "bitflags",
- "textwrap",
- "unicode-width",
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
 ]
 
 [[package]]
-name = "cloudabi"
-version = "0.0.3"
+name = "ciborium-io"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
- "bitflags",
+ "ciborium-io",
+ "half",
 ]
+
+[[package]]
+name = "clap"
+version = "4.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd304a20bff958a57f04c4e96a2e7594cc4490a0e809cbd48bb6437edaa452d"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c6a3f08f1fe5662a35cfe393aec09c4df95f60ee93b7556505260f75eee9e1"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "criterion"
-version = "0.3.5"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
 dependencies = [
- "atty",
+ "anes",
  "cast",
+ "ciborium",
  "clap",
  "criterion-plot",
- "csv",
+ "is-terminal",
  "itertools",
- "lazy_static",
  "num-traits",
+ "once_cell",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_cbor",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -127,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools",
@@ -162,7 +171,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "lazy_static",
@@ -187,38 +196,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "csv"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
-dependencies = [
- "bstr",
- "csv-core",
- "itoa 0.4.8",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
+name = "errno"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "getopts"
@@ -227,6 +229,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -245,6 +258,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi 0.3.2",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,12 +282,6 @@ checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
-
-[[package]]
-name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -282,9 +306,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "log"
@@ -296,18 +326,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -316,7 +340,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -325,9 +349,15 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "oorandom"
@@ -364,6 +394,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,108 +419,32 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.6.5"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "autocfg 0.1.8",
  "libc",
  "rand_chacha",
- "rand_core 0.4.2",
- "rand_hc",
- "rand_isaac",
- "rand_jitter",
- "rand_os",
- "rand_pcg",
- "rand_xorshift",
- "winapi",
+ "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-dependencies = [
- "autocfg 0.1.8",
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
- "rand_core 0.4.2",
+ "ppv-lite86",
+ "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.4.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.8",
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-dependencies = [
- "rand_core 0.3.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -493,7 +453,7 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -512,15 +472,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
 name = "regex"
 version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,12 +479,6 @@ checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
  "regex-syntax",
 ]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -553,12 +498,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
+name = "rustix"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
 dependencies = [
- "semver",
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -584,9 +533,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "secp256k1"
-version = "0.22.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26947345339603ae8395f68e2f3d85a6b0a8ddfe6315818e80b8504415099db0"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
  "rand",
  "secp256k1-sys",
@@ -594,33 +543,20 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.5.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152e20a0fd0519390fc43ab404663af8a0b794273d2a91d60ad4a39f13ffe110"
+checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
 
 [[package]]
 name = "serde"
 version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
- "half",
- "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -640,7 +576,7 @@ version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
- "itoa 1.0.2",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -654,15 +590,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -718,6 +645,12 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -813,3 +746,69 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,14 @@ edition = "2021"
 
 [dependencies]
 getopts = "0.2"
-num_cpus = "1.13"
-secp256k1 = { version = "0.27", features = ["std", "rand-std", "global-context"] }
-tiny-keccak = { version = "2.0", features = ["keccak"] }
-rust_decimal = { version = "1.23", features = ["maths"] }
+num_cpus = "1"
 regex = "1"
+secp256k1 = { version = "0.27", features = ["std", "rand-std", "global-context"] }
+tiny-keccak = { version = "2", features = ["keccak"] }
+rust_decimal = { version = "1", features = ["maths"] }
 
 [dev-dependencies]
-criterion = "0.5.1"
+criterion = "0.5"
 
 [[bench]]
 name = "checksum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinyvanityeth"
-version = "1.0.0"
+version = "1.1.0"
 description = "Tiny and fast command line tool to find vanity Ethereum addresses."
 authors = ["Csongor Bokay <8850110+bcsongor@users.noreply.github.com>"]
 license = "GPL-3.0-or-later"
@@ -16,6 +16,7 @@ num_cpus = "1.13"
 secp256k1 = { version = "0.27", features = ["std", "rand-std", "global-context"] }
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 rust_decimal = { version = "1.23", features = ["maths"] }
+regex = "1"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ edition = "2021"
 [dependencies]
 getopts = "0.2"
 num_cpus = "1.13"
-secp256k1 = { version = "0.22", features = ["std", "rand-std", "global-context"] }
+secp256k1 = { version = "0.27", features = ["std", "rand-std", "global-context"] }
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 rust_decimal = { version = "1.23", features = ["maths"] }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.5.1"
 
 [[bench]]
 name = "checksum"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Tiny and _fast_ command line tool to find vanity Ethereum addresses that match a
 
 On macOS, use Homebrew to install Rust & Cargo via `brew install rustup`.
 
-For other platforms, please see the [official installation guide](https://doc.rust-lang.org/cargo/getting-started/installation.html). 
+For other platforms, please see the [official installation guide](https://doc.rust-lang.org/cargo/getting-started/installation.html).
 
 ### Installing _tinyvanityeth_
 
@@ -35,32 +35,43 @@ Options:
     -c, --case-sensitive    enables case-sensitive search
     -p, --prefix PREFIX     address prefix to search for
     -s, --suffix SUFFIX     address suffix to search for
+    -r, --regexp REGEXP     regular expression to search for
     -t, --threads COUNT     number of threads to use (default num_cpus)
     -i, --interval SECONDS  statistics print interval (default 10)
 ```
+Suffix or prefix and regular expression rules are mutually exclusive.
 
 ### Examples
 
-#### Find an address that starts with `5eaf00d`
-```bash
+#### Find an address that starts with `5eaf00d`.
+```shell
 tinyvanityeth -p 5eaf00d
 ```
 
-#### Find an address that ends with `5eaf00d`
-```bash
+#### Find an address that ends with `5eaf00d`.
+```shell
 tinyvanityeth -s 5eaf00d
 ```
 
 #### Find a checksum address that starts with `5EAF00D`, print statistics every minute.
-```bash
+```shell
 tinyvanityeth -c -p 5EAF00D -s 60
 ```
 
-#### Find an address that starts and ends with `000`
-```bash
+#### Find an address that starts and ends with `000`.
+```shell
 tinyvanityeth -p 000 -s 000
 ```
 
+#### Find an address that contains `00000`.
+```shell
+tinyvanityeth -r '0{5}'
+```
+
+#### Find a checksum address that either starts with `B000` or ends with `F000`.
+```shell
+tinyvanityeth -c -r '^B000|F000$'
+```
 
 ## 🚀 Performance
 
@@ -91,7 +102,7 @@ Case-insensitive search for an address with the prefix `5eaf00d`. 🍣
 
 ### Build
 
-Please note, _release_ builds contain optimisations which can positively affect performance. 
+Please note, _release_ builds contain optimisations which can positively affect performance.
 It is not recommended to use _debug_ builds for searching addresses.
 
 ```shell
@@ -104,6 +115,6 @@ cargo build --release
 
 ### Run unit tests
 
-```shell 
+```shell
 cargo test
 ```

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 # 📥 To do
 
 - [x] Search addresses by suffix
-- [ ] Search for addresses that match a regexp pattern
-- [ ] Support searching for addresses by multiple criteria
+- [x] Search for addresses that match a regexp pattern
+- [x] Support searching for addresses by multiple criteria _(possible via regexp rules)_

--- a/TODO.md
+++ b/TODO.md
@@ -3,3 +3,4 @@
 - [x] Search addresses by suffix
 - [x] Search for addresses that match a regexp pattern
 - [x] Support searching for addresses by multiple criteria _(possible via regexp rules)_
+- [ ] Update benchmarks

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use getopts::{Matches, Options};
+use regex::{Regex, RegexBuilder};
 use rust_decimal::{Decimal, MathematicalOps};
 use secp256k1::generate_keypair;
 use secp256k1::rand::thread_rng;
@@ -42,6 +43,8 @@ struct Rules {
     prefix: Option<AddressPart>,
     /// Address suffix to match.
     suffix: Option<AddressPart>,
+    /// Regular expression to match.
+    regexp: Option<Regex>,
 }
 
 /// Application configuration.
@@ -59,8 +62,12 @@ impl TryFrom<Matches> for Configuration {
     type Error = &'static str;
 
     fn try_from(matches: Matches) -> Result<Self, Self::Error> {
-        if !matches.opt_present("p") && !matches.opt_present("s") {
-            return Err("prefix and/or suffix must be present");
+        if (!matches.opt_present("p") && !matches.opt_present("s")) && !matches.opt_present("r") {
+            return Err("prefix and/or suffix or a regexp must be present");
+        }
+
+        if (matches.opt_defined("p") || matches.opt_present("s")) && matches.opt_present("r") {
+            return Err("suffix or prefix and regexp rules are mutually exclusive");
         }
 
         let prefix = matches.opt_str("p").map(AddressPart::from);
@@ -81,6 +88,13 @@ impl TryFrom<Matches> for Configuration {
 
         let is_case_sensitive = matches.opt_present("c");
 
+        let regexp = matches.opt_str("r").as_ref().map(|rs| {
+            RegexBuilder::new(rs)
+                .case_insensitive(!is_case_sensitive)
+                .build()
+                .expect("regexp must be a valid regular expression")
+        });
+
         let thread_count: usize = matches
             .opt_get("t")
             .map_err(|_| "failed to parse thread count")?
@@ -98,6 +112,7 @@ impl TryFrom<Matches> for Configuration {
                 is_case_sensitive,
                 prefix,
                 suffix,
+                regexp,
             },
         })
     }
@@ -176,7 +191,12 @@ fn to_checksum_address<'a>(addr: &str, checksum_addr_hex_buf: &'a mut [u8]) -> &
 }
 
 /// Calculates the difficulty of finding an address given `rules`.
-fn calc_difficulty(rules: &Rules) -> u128 {
+fn calc_difficulty(rules: &Rules) -> Option<u128> {
+    // Ignore difficulty calculation if a regexp rule is present.
+    if rules.regexp.is_some() {
+        return None;
+    }
+
     const HEX_CHAR_COUNT: u128 = 16u128;
 
     let prefix = rules.prefix.as_ref().map_or("", |p| &p.part);
@@ -195,9 +215,9 @@ fn calc_difficulty(rules: &Rules) -> u128 {
             .filter(|&c| *c < b'0' || *c > b'9')
             .count();
 
-        base_difficulty * UPPER_LOWER_LETTER_COUNT.pow(letter_count as u32)
+        Some(base_difficulty * UPPER_LOWER_LETTER_COUNT.pow(letter_count as u32))
     } else {
-        base_difficulty
+        Some(base_difficulty)
     }
 }
 
@@ -216,20 +236,30 @@ fn print_usage(program: &str, opts: Options) {
 
 /// Checks if an address `addr` matches the `rules`.
 fn is_addr_matching(rules: &Rules, addr: &str) -> bool {
-    let prefix = rules.prefix.as_ref();
-    let suffix = rules.suffix.as_ref();
+    match rules.regexp.as_ref() {
+        Some(regexp) => regexp.is_match(addr),
+        None => {
+            let prefix = rules.prefix.as_ref();
+            let suffix = rules.suffix.as_ref();
 
-    prefix.map_or(true, |p| addr.starts_with(&p.part_lower))
-        && suffix.map_or(true, |s| addr.ends_with(&s.part_lower))
+            prefix.map_or(true, |p| addr.starts_with(&p.part_lower))
+                && suffix.map_or(true, |s| addr.ends_with(&s.part_lower))
+        }
+    }
 }
 
 /// Checks if a checksum address `checksum_addr` matches the given `rules`.
 fn is_checksum_addr_matching(rules: &Rules, checksum_addr: &str) -> bool {
-    let prefix = rules.prefix.as_ref();
-    let suffix = rules.suffix.as_ref();
+    match rules.regexp.as_ref() {
+        Some(regexp) => regexp.is_match(checksum_addr),
+        None => {
+            let prefix = rules.prefix.as_ref();
+            let suffix = rules.suffix.as_ref();
 
-    prefix.map_or(true, |p| checksum_addr.starts_with(&p.part))
-        && suffix.map_or(true, |s| checksum_addr.ends_with(&s.part))
+            prefix.map_or(true, |p| checksum_addr.starts_with(&p.part))
+                && suffix.map_or(true, |s| checksum_addr.ends_with(&s.part))
+        }
+    }
 }
 
 fn main() {
@@ -240,6 +270,7 @@ fn main() {
     opts.optflag("c", "case-sensitive", "enables case-sensitive search");
     opts.optopt("p", "prefix", "address prefix to search for", "PREFIX");
     opts.optopt("s", "suffix", "address suffix to search for", "SUFFIX");
+    opts.optopt("r", "regexp", "regular expression to search for", "REGEXP");
     opts.optopt("t", "threads", "number of threads to use", "COUNT");
     opts.optopt("i", "interval", "statistics print interval", "SECONDS");
 
@@ -291,12 +322,16 @@ fn main() {
 
                 generated.fetch_add(1, Ordering::Relaxed);
 
-                // Match address against lowercase prefix.
-                if is_addr_matching(&rules, addr) {
+                // Match non-checksummed address against rules.
+                // If there's a regexp rule & case sensitivity is enabled proceed to
+                // match the checksum address instead.
+                if (rules.regexp.is_some() && rules.is_case_sensitive)
+                    || is_addr_matching(&rules, addr)
+                {
                     let checksum_addr = to_checksum_address(&addr, &mut checksum_addr_hex_buf);
 
-                    // Lowercase prefix matched, if case sensitivity is enabled,
-                    // check if prefix matches the checksum address.
+                    // Lowercase address matched, if case sensitivity is enabled,
+                    // check if rules matche the checksum address.
                     if rules.is_case_sensitive && !is_checksum_addr_matching(&rules, checksum_addr)
                     {
                         continue;
@@ -325,10 +360,10 @@ fn main() {
         let mut last_loop: Option<Instant> = None;
 
         while !found.load(Ordering::Acquire) {
-            let delta_ms = last_loop.map_or(0u128, |last_loop| {
-                Instant::now().duration_since(last_loop).as_millis()
-            });
-            last_loop = Some(Instant::now());
+            let now = Instant::now();
+            let delta_ms =
+                last_loop.map_or(0u128, |last_loop| now.duration_since(last_loop).as_millis());
+            last_loop = Some(now);
 
             if delta_ms > 0 {
                 let curr_generated = generated.swap(0, Ordering::Relaxed);
@@ -337,17 +372,34 @@ fn main() {
                     .round();
                 total_generated += curr_generated as u128;
 
-                let probability = calc_probability(difficulty, total_generated);
-                let probability_pct = (probability * Decimal::ONE_HUNDRED).round_dp(3);
+                // If difficulty is not available (e.g. because of a regexp rule) print basic metrics only.
+                match difficulty {
+                    Some(difficulty) => {
+                        let probability = calc_probability(difficulty, total_generated);
+                        let probability_pct = (probability * Decimal::ONE_HUNDRED).round_dp(3);
 
-                println!(
-                    "Status ({} threads)\n  \
-                      Difficulty:  {}\n  \
-                      Generated:   {} addresses\n  \
-                      Speed:       {} addr/s\n  \
-                      Probability: {}%",
-                    cfg.thread_count, difficulty, total_generated, addr_per_sec, probability_pct
-                );
+                        println!(
+                            "Status ({} threads)\n  \
+                              Difficulty:  {}\n  \
+                              Generated:   {} addresses\n  \
+                              Speed:       {} addr/s\n  \
+                              Probability: {}%",
+                            cfg.thread_count,
+                            difficulty,
+                            total_generated,
+                            addr_per_sec,
+                            probability_pct
+                        );
+                    }
+                    None => {
+                        println!(
+                            "Status ({} threads)\n  \
+                              Generated:   {} addresses\n  \
+                              Speed:       {} addr/s",
+                            cfg.thread_count, total_generated, addr_per_sec,
+                        );
+                    }
+                }
             }
 
             thread::sleep(interval);
@@ -366,12 +418,17 @@ mod tests {
         calc_difficulty, calc_probability, is_addr_matching, is_lower_hex, to_checksum_address,
         to_hex, AddressPart, Rules, ADDRESS_HEX_LENGTH,
     };
+    use regex::RegexBuilder;
     use rust_decimal::Decimal;
 
-    fn get_rules(prefix: Option<&str>, suffix: Option<&str>, is_case_sensitive: bool) -> Rules {
+    fn get_rules(prefix: Option<&str>, suffix: Option<&str>, regexp: Option<&str>, is_case_sensitive: bool) -> Rules {
         Rules {
             prefix: prefix.map(AddressPart::from),
             suffix: suffix.map(AddressPart::from),
+            regexp: regexp.map(|rs| RegexBuilder::new(rs)
+                .case_insensitive(!is_case_sensitive)
+                .build()
+                .unwrap()),
             is_case_sensitive,
         }
     }
@@ -435,16 +492,19 @@ mod tests {
 
     #[test]
     fn it_should_calculate_difficulty() {
-        assert_eq!(calc_difficulty(&get_rules(Some(""), None, false)), 1);
-        assert_eq!(calc_difficulty(&get_rules(Some(""), None, true)), 1);
-        assert_eq!(calc_difficulty(&get_rules(Some("0000"), None, false)), 65_536);
-        assert_eq!(calc_difficulty(&get_rules(Some("0000"), None, true)), 65_536);
-        assert_eq!(calc_difficulty(&get_rules(Some("5eaf00d"), None, false)), 268_435_456);
-        assert_eq!(calc_difficulty(&get_rules(Some("5eaf00d"), None, true)), 4_294_967_296);
-        assert_eq!(calc_difficulty(&get_rules(None, Some("5eaf00d"), false)), 268_435_456);
-        assert_eq!(calc_difficulty(&get_rules(None, Some("5eaf00d"), true)), 4_294_967_296);
-        assert_eq!(calc_difficulty(&get_rules(Some("00"), Some("11"), false)), 65_536);
-        assert_eq!(calc_difficulty(&get_rules(Some("00"), Some("11"), true)), 65_536);
+        assert_eq!(calc_difficulty(&get_rules(Some(""), None, None, false)), Some(1));
+        assert_eq!(calc_difficulty(&get_rules(Some(""), None, None, true)), Some(1));
+        assert_eq!(calc_difficulty(&get_rules(Some("0000"), None, None, false)), Some(65_536));
+        assert_eq!(calc_difficulty(&get_rules(Some("0000"), None, None, true)), Some(65_536));
+        assert_eq!(calc_difficulty(&get_rules(Some("5eaf00d"), None, None, false)), Some(268_435_456));
+        assert_eq!(calc_difficulty(&get_rules(Some("5eaf00d"), None, None, true)), Some(4_294_967_296));
+        assert_eq!(calc_difficulty(&get_rules(None, Some("5eaf00d"), None, false)), Some(268_435_456));
+        assert_eq!(calc_difficulty(&get_rules(None, Some("5eaf00d"), None, true)), Some(4_294_967_296));
+        assert_eq!(calc_difficulty(&get_rules(Some("00"), Some("11"), None, false)), Some(65_536));
+        assert_eq!(calc_difficulty(&get_rules(Some("00"), Some("11"), None, true)), Some(65_536));
+        assert_eq!(calc_difficulty(&get_rules(None, None, Some(""), false)), None);
+        assert_eq!(calc_difficulty(&get_rules(None, None, Some("0{7}"), false)), None);
+        assert_eq!(calc_difficulty(&get_rules(None, None, Some("0{7}"), true)), None);
     }
 
     #[test]
@@ -468,14 +528,34 @@ mod tests {
 
     #[test]
     fn it_should_match_addr() {
-        let rules = get_rules(Some("0000"), None, false);
+        let rules = get_rules(Some("0000"), None, None, false);
         assert_eq!(is_addr_matching(&rules, "00000000219ab540356cbb839cbe05303d7705fa"), true);
         assert_eq!(is_addr_matching(&rules, "ff000000219ab540356cbb839cbe05303d7705fa"), false);
         assert_eq!(is_addr_matching(&rules, "ff000000219ab540356cbb839cbe05303d770000"), false);
 
-        let rules = get_rules(None, Some("0000"), false);
+        let rules = get_rules(None, Some("0000"), None, false);
         assert_eq!(is_addr_matching(&rules, "ff000000219ab540356cbb839cbe05303d770000"), true);
         assert_eq!(is_addr_matching(&rules, "ff000000219ab540356cbb839cbe05303d7705fa"), false);
         assert_eq!(is_addr_matching(&rules, "00000000219ab540356cbb839cbe05303d7705fa"), false);
+
+        let rules = get_rules(None, None, Some("^0{4}"), false);
+        assert_eq!(is_addr_matching(&rules, "00000000219ab540356cbb839cbe05303d7705fa"), true);
+        assert_eq!(is_addr_matching(&rules, "ff000000219ab540356cbb839cbe05303d7705fa"), false);
+        assert_eq!(is_addr_matching(&rules, "ff000000219ab540356cbb839cbe05303d770000"), false);
+
+        let rules = get_rules(None, None, Some("0{4}$"), false);
+        assert_eq!(is_addr_matching(&rules, "ff000000219ab540356cbb839cbe05303d770000"), true);
+        assert_eq!(is_addr_matching(&rules, "ff000000219ab540356cbb839cbe05303d7705fa"), false);
+        assert_eq!(is_addr_matching(&rules, "00000000219ab540356cbb839cbe05303d7705fa"), false);
+
+        let rules = get_rules(None, None, Some("^abcd{2}"), false);
+        assert_eq!(is_addr_matching(&rules, "abcdd000219ab540356cbb839cbe05303d770000"), true);
+        assert_eq!(is_addr_matching(&rules, "ABcDD000219ab540356cbb839cbe05303d770000"), true);
+        assert_eq!(is_addr_matching(&rules, "ff000000219ab540356cbb839cbe05303d7705fa"), false);
+        assert_eq!(is_addr_matching(&rules, "00000000219ab540356cbb839cbe05303d7705fa"), false);
+
+        let rules = get_rules(None, None, Some("^A{3}"), true);
+        assert_eq!(is_addr_matching(&rules, "AAADD000219ab540356cbb839cbe05303d770000"), true);
+        assert_eq!(is_addr_matching(&rules, "aaaDD000219ab540356cbb839cbe05303d770000"), false);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -331,7 +331,7 @@ fn main() {
                     let checksum_addr = to_checksum_address(&addr, &mut checksum_addr_hex_buf);
 
                     // Lowercase address matched, if case sensitivity is enabled,
-                    // check if rules matche the checksum address.
+                    // check if rules match the checksum address.
                     if rules.is_case_sensitive && !is_checksum_addr_matching(&rules, checksum_addr)
                     {
                         continue;

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ impl TryFrom<Matches> for Configuration {
             return Err("prefix and/or suffix or a regexp must be present");
         }
 
-        if (matches.opt_defined("p") || matches.opt_present("s")) && matches.opt_present("r") {
+        if (matches.opt_present("p") || matches.opt_present("s")) && matches.opt_present("r") {
             return Err("suffix or prefix and regexp rules are mutually exclusive");
         }
 


### PR DESCRIPTION
- [x] Add support for searching addresses by a regular expression (this option is mutually exclusive with prefix and suffix rules)
- [x] Update `secp256k1` (gives 15-20% performance boost on modern Intel CPUs) and other dependencies to latest version