### PR TITLE
Use numerically stable formula to calculate address match probability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "tinyvanityeth"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "criterion",
  "getopts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinyvanityeth"
-version = "1.1.0"
+version = "1.1.1"
 description = "Tiny and fast command line tool to find vanity Ethereum addresses."
 authors = ["Csongor Bokay <8850110+bcsongor@users.noreply.github.com>"]
 license = "GPL-3.0-or-later"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# tinyvanityeth ✨ [![Build](https://github.com/bcsongor/tinyvanityeth/actions/workflows/build.yml/badge.svg)](https://github.com/bcsongor/tinyvanityeth/actions/workflows/build.yml)
+# tinyvanityeth ✨ [![Build](https://github.com/bcsongor/tinyvanityeth/actions/workflows/build.yml/badge.svg)](https://github.com/bcsongor/tinyvanityeth/actions/workflows/build.yml) ![GitHub tag (with filter)](https://img.shields.io/github/v/tag/bcsongor/tinyvanityeth?label=version)
 
 Tiny and _fast_ command line tool to find vanity Ethereum addresses that match a given prefix, suffix, or both.
 


### PR DESCRIPTION
This PR fixes `calc_probability(...)` panicking with `Pow overflowed` when the number of generated addresses is larger than `u32::MAX`.

Fixes #2 (kudos to @seequick for reporting this).